### PR TITLE
Changed sort to be numeric to fix bug with values over 10

### DIFF
--- a/app/js/index.js
+++ b/app/js/index.js
@@ -242,7 +242,9 @@
 
 		// TODO: See about optimising this so sorting is included in the above loops
 		for (var effect in sorted) {
-			sorted[effect].sort();
+			sorted[effect].sort(function(a, b) {
+  				return a - b;
+			});
 		}
 
 		return sorted;


### PR DESCRIPTION
I was using your calculator and for values over 10 the stats seemed to be incorrect.  Doesn't happen much except for range but here is a fix to sort numerically